### PR TITLE
Automation for processing core packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ Reference mobile and website implementation for RainCatcher
 ## About RainCatcher Angularjs
 
 RainCatcher Angularjs is reference mobile and website implementation for [Raincatcher Core Framework](https://github.com/feedhenry-raincatcher/raincatcher-core).
-For more information about RainCatcher please refer to main repository.
 
 ## Quick start
 
@@ -17,6 +16,8 @@ Start demo applications
 
     npm run start
 
+Note: Core repository will be automatically fetched using git command.
+If you wish to work with different branch of the core repository please switch manually.
 
 ## Repository folder structure
 
@@ -24,11 +25,14 @@ This repository contains many subpackages managed through [Lerna](https://lernaj
 contained in the following directories:
 
 <dl>
-  <dt>angularjs/</dt>
+  <dt>packages/</dt>
   <dd>Packages implementing angularjs directives and other ui components used in demo applications</dd>
 
   <dt>demo/</dt>
   <dd>Full-fledged demo applications, showcasing the usage of multiple modules</dd>
+
+  <dt>core/client</dt>
+  <dd>Client side modules from core repository</dd>
 </dl>
 
 ### Repository commands

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,8 @@
   "lerna": "2.0.0-rc.5",
   "packages": [
     "packages/*",
-    "demo/*"
+    "demo/*",
+    "core/client/*"
   ],
   "version": "independent"
 }

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "lerna run test",
-    "cleanInstall": "lerna exec npm install --ignore-scripts",
-    "bootstrap": "lerna bootstrap",
+    "bootstrap": "node ./scripts/checkoutCore.js && lerna bootstrap",
     "start": "lerna run start  --parallel --stream --scope=@raincatcher/demo-*"
   },
   "repository": {

--- a/scripts/checkoutCore.js
+++ b/scripts/checkoutCore.js
@@ -1,0 +1,83 @@
+var spawn = require('child_process').spawn;
+var fs = require('fs');
+
+var REPOSITORY_NAME = "git@github.com:feedhenry-raincatcher/raincatcher-core.git";
+var LOCATION = "./core";
+
+console.log("Linking core repository");
+
+if (fs.existsSync(LOCATION)) {
+  console.log("Core repository already exist. Pulling recent changes.");
+  return pull(LOCATION, { remote: "origin", branch: "master" }, function (err) {
+    if (err) {
+      return console.log("Failed to pull from repository", err);
+    }
+    console.log("Successfully updated core repository");
+  });
+};
+
+clone(REPOSITORY_NAME, "./core", { shallow: false, checkout: "master" }, function (err) {
+  if (err) {
+    return console.log("Failed to clone repository", err);
+  }
+  console.log("Successfully cloned core repository");
+});
+
+// Clone repository
+function clone(repo, targetPath, opts, cb) {
+  if (typeof opts === 'function') {
+    cb = opts;
+    opts = null;
+  }
+  opts = opts || {};
+  var git = opts.git || 'git';
+  var args = ['clone'];
+
+  if (opts.shallow) {
+    args.push('--depth');
+    args.push('1');
+  }
+
+  args.push('--');
+  args.push(repo);
+  args.push(targetPath);
+
+  var process = spawn(git, args);
+  process.on('close', function (status) {
+    if (status == 0) {
+      if (opts.checkout) {
+        _checkout();
+      } else {
+        cb && cb();
+      }
+    } else {
+      cb && cb(new Error("'git clone' failed with status " + status));
+    }
+  });
+
+  function _checkout() {
+    var args = ['checkout', opts.checkout];
+    var process = spawn(git, args, { cwd: targetPath });
+    process.on('close', function (status) {
+      if (status == 0) {
+        cb && cb();
+      } else {
+        cb && cb(new Error("'git checkout' failed with status " + status));
+      }
+    });
+  }
+}
+
+// Pull recent changes
+function pull(targetPath, opts, cb) {
+  var git = opts.git || 'git';
+  var args = ['pull', opts.remote, opts.branch];
+  var process = spawn(git, args, { cwd: targetPath });
+  process.on('close', function (status) {
+    if (status == 0) {
+      cb && cb();
+    } else {
+      cb && cb(new Error("'git pull' failed with status " + status));
+    }
+  });
+}


### PR DESCRIPTION
## Motivation

Automatically link core repository.

We checking out entire repository but only client packages are used 
That's why we had that separation in the first place.

I just noticed that logger package is missing. ping @austincunningham 
Some small changes in core are needed in order to compile client code.
For clients we will need to compile our changes every time as we reference to this from non typescript javascript implementation. 

## Ideas

- I think we should also add automation to launch demo-mobile
Angular-js repo will become central point for all work.

## Note 

@feedhenry-raincatcher/rcdev 
This will change workflow for all developers, by simplifying it to minimum. 
We will need to migrate to new core repository that will be now part of the angular-js repository.