### PR TITLE
[RAINCATCH-1028] Integrate Passport security with demo mobile

### DIFF
--- a/demo/mobile/src/app/initialisation/config.js
+++ b/demo/mobile/src/app/initialisation/config.js
@@ -1,5 +1,7 @@
+var fh = require('fh-js-sdk');
 
-function createMainAppRoute($stateProvider, $urlRouterProvider) {
+function createMainAppRoute($stateProvider, $urlRouterProvider, $httpProvider) {
+  $httpProvider.defaults.withCredentials = true;
   // if none of the states are matched, use this as the fallback
 
   $urlRouterProvider.otherwise(function($injector) {
@@ -15,10 +17,10 @@ function createMainAppRoute($stateProvider, $urlRouterProvider) {
     });
 }
 
-angular.module('wfm-mobile').config(['$stateProvider', '$urlRouterProvider', createMainAppRoute]).controller('mainController', [
-  '$rootScope', '$scope', '$state', '$mdSidenav', 'userService',
-  function($rootScope, $scope, $state, $mdSidenav, userService) {
-    userService.getProfile().then(function(profileData) {
+angular.module('wfm-mobile').config(['$stateProvider', '$urlRouterProvider', '$httpProvider', createMainAppRoute]).controller('mainController', [
+  '$rootScope', '$scope', '$state', '$mdSidenav', 'userService', '$window', '$http',
+  function ($rootScope, $scope, $state, $mdSidenav, userService, $window, $http) {
+    userService.getProfile($http, $window).then(function (profileData) {
       $scope.profileData = profileData;
     });
     $scope.toggleSidenav = function(event, menuId) {
@@ -30,4 +32,18 @@ angular.module('wfm-mobile').config(['$stateProvider', '$urlRouterProvider', cre
         $state.go(state, params);
       }
     };
+    $scope.logout = function() {
+      if($scope.profileData) {
+        var req = {
+          method: 'GET',
+          url: fh.getCloudURL() + '/logout'
+        };
+
+        return $http(req, {withCredentials: true}).then(function(res) {
+          $window.location = fh.getCloudURL() + '/login';
+        }, function(err) {
+          console.log('error logging out');
+        });
+      }
+    }
   }]);

--- a/demo/mobile/src/app/main.tpl.html
+++ b/demo/mobile/src/app/main.tpl.html
@@ -25,7 +25,7 @@
       </md-list-item>
       <md-divider></md-divider>
 
-      <md-list-item>
+      <md-list-item ng-click="logout()">
         <md-icon md-font-set="material-icons">power_settings_new</md-icon>
         <p>Logout</p>
       </md-list-item>

--- a/demo/mobile/src/app/services/userService.js
+++ b/demo/mobile/src/app/services/userService.js
@@ -1,4 +1,5 @@
 var Promise = require("bluebird");
+var fh = require("fh-js-sdk");
 
 function UserService() {
 }
@@ -18,9 +19,22 @@ UserService.prototype.readUser = function readUser(userId) {
   });
 };
 
-
-UserService.prototype.getProfile = function(userId) {
-  return this.readUser(userId);
+UserService.prototype.getProfile = function($http, $window) {
+  var req = {
+    method: 'GET',
+    url: fh.getCloudURL() + '/profile'
+  };
+  return $http(req, {withCredentials: true}).then(function(res) {
+    return res.data;
+  }, function(err) {
+    if (err.status === 401) {
+      $window.location = fh.getCloudURL() + '/login';
+    }
+    if (err.status === 403) {
+      console.log('Forbidden')
+    }
+    return err;
+  });
 };
 
 UserService.prototype.listUsers = function listUsers() {

--- a/demo/sync/syncServices.js
+++ b/demo/sync/syncServices.js
@@ -1,7 +1,7 @@
 var config = require('./config.json');
 var _ = require('lodash');
-angular.module('wfm.sync').service('syncService', ['syncPool' , 'userService', function(syncPool, userService) {
-  return userService.getProfile()
+angular.module('wfm.sync',[]).service('syncService', ['$http', '$window', 'syncPool', 'userService', function ($http, $window, syncPool, userService) {
+  return userService.getProfile($http, $window)
     .then(syncPool.syncManagerMap);
 }]);
 


### PR DESCRIPTION
## Motivation
The demo mobile will require some form of authentication. Passport needs to be integrated with the demo solutions. Allow credentials to be passed with the request for authentication. 

## Description
Integrate Passport security with the demo mobile app. This should provide getProfile, login and logout functionality.

## Progress
- [x] Add getProfile functionality
- [x] Enable logout functionality

## Additional Notes
Related JIRA - https://issues.jboss.org/browse/RAINCATCH-1028
Related PR - https://github.com/feedhenry-raincatcher/raincatcher-core/pull/60
