### PR TITLE
[RAINCATCH-1110] Integrate Passport auth module with the portal app

### DIFF
--- a/demo/mobile/package.json
+++ b/demo/mobile/package.json
@@ -20,6 +20,7 @@
     "@raincatcher/workflow-angular": "1.0.0",
     "@raincatcher/workorder-angular": "1.0.0",
     "@raincatcher/vehicle-inspection": "1.0.0",
+    "@raincatcher/dialog": "1.0.0",
     "@raincatcher/demo-auth-passport": "1.0.0",
     "@raincatcher/demo-sync": "1.0.0",
     "@raincatcher/demo-wfm": "1.0.0",

--- a/demo/mobile/src/app/app.js
+++ b/demo/mobile/src/app/app.js
@@ -13,7 +13,7 @@ angular.module('wfm-mobile', [
   require('angular-material'),
   require('@raincatcher/dialog'),
   // Enables passport auth service to be used
-  require('@raincatcher/demo-auth-passport'),
+  require('@raincatcher/demo-auth-passport')('wfm-mobile'),
   require('./services'),
   require('@raincatcher/demo-wfm'),
   require('@raincatcher/demo-sync'),

--- a/demo/mobile/src/app/app.js
+++ b/demo/mobile/src/app/app.js
@@ -11,7 +11,7 @@ logger.setLogger(new logger.ClientLogger(2));
 angular.module('wfm-mobile', [
   require('angular-ui-router'),
   require('angular-material'),
-  require('./util'),
+  require('@raincatcher/dialog'),
   // Enables passport auth service to be used
   require('@raincatcher/demo-auth-passport'),
   require('./services'),

--- a/demo/mobile/src/app/util/index.js
+++ b/demo/mobile/src/app/util/index.js
@@ -1,5 +1,0 @@
-angular.module('wfm.common.util', []);
-
-require('./dialog');
-
-module.exports = 'wfm.common.util';

--- a/demo/portal/package.json
+++ b/demo/portal/package.json
@@ -15,6 +15,8 @@
   "author": "feedhenry-raincatcher@redhat.com",
   "license": "MIT",
   "dependencies": {
+    "@raincatcher/demo-auth-passport": "1.0.0",
+    "@raincatcher/dialog": "1.0.0",
     "@raincatcher/demo-sync": "1.0.0",
     "@raincatcher/demo-wfm": "1.0.0",
     "@raincatcher/logger": "1.0.0",

--- a/demo/portal/src/app/config.js
+++ b/demo/portal/src/app/config.js
@@ -24,12 +24,25 @@ function AppConfig($stateProvider, $urlRouterProvider) {
       data: {
         columns: 3
       },
-      controller: function($scope, $state, $mdSidenav) {
+      controller: function($scope, $state, $mdSidenav, userService, dialogService) {
+        userService.getProfile().then(function(profileData) {
+          $scope.profileData = profileData;
+        }).catch(function(err) {
+          dialogService.showAlert({
+            title: 'Failed to Load Profile Data',
+            textContent: 'Unable to load profile data due to the following error: ' + err + 'Please login',
+            ok: 'Login'
+          }).then(function() {
+            userService.login();
+          });
+        });
+
         $scope.$state = $state;
         $scope.toggleSidenav = function(event, menuId) {
           $mdSidenav(menuId).toggle();
           event.stopPropagation();
         };
+
         $scope.navigateTo = function(state, params) {
           if (state) {
             if ($mdSidenav('left').isOpen()) {
@@ -37,6 +50,14 @@ function AppConfig($stateProvider, $urlRouterProvider) {
             }
             $state.go(state, params);
           }
+        };
+
+        $scope.hasResourceRole = function(role) {
+          return userService.hasResourceRole(role);
+        };
+
+        $scope.logout = function() {
+          userService.logout();
         };
       }
     });

--- a/demo/portal/src/app/main.js
+++ b/demo/portal/src/app/main.js
@@ -9,6 +9,8 @@ logger.setLogger(new logger.ClientLogger(2));
 angular.module('app', [
   require('angular-ui-router'),
   require('angular-material'),
+  require('@raincatcher/dialog'),
+  require('@raincatcher/demo-auth-passport'),
   require('./services'),
   require('@raincatcher/demo-wfm'),
   require('@raincatcher/demo-sync'),

--- a/demo/portal/src/app/main.js
+++ b/demo/portal/src/app/main.js
@@ -10,7 +10,7 @@ angular.module('app', [
   require('angular-ui-router'),
   require('angular-material'),
   require('@raincatcher/dialog'),
-  require('@raincatcher/demo-auth-passport'),
+  require('@raincatcher/demo-auth-passport')('app'),
   require('./services'),
   require('@raincatcher/demo-wfm'),
   require('@raincatcher/demo-sync'),

--- a/demo/portal/src/app/main.tpl.html
+++ b/demo/portal/src/app/main.tpl.html
@@ -9,7 +9,7 @@
 
   <div layout="row" flex>
 
-    <md-sidenav layout="column" class="md-sidenav-left md-whiteframe-z2" md-component-id="left" md-is-locked-open="$mdMedia('gt-sm')">
+    <md-sidenav ng-if="profileData" layout="column" class="md-sidenav-left md-whiteframe-z2" md-component-id="left" md-is-locked-open="$mdMedia('gt-sm')">
       <md-list>
         <md-list-item ng-click="navigateTo('app.workorder')" ng-class="{active: $state.includes('app.workorder')}">
           <md-icon md-font-set="material-icons">assignment</md-icon>
@@ -29,7 +29,7 @@
       </md-list>
     </md-sidenav>
 
-    <md-content id="content" layout="row" flex>
+    <md-content ng-if="profileData" id="content" layout="row" flex>
       <div flex="33" ui-view name="column2" class="inner-column" ng-class="{hide: $state.current.data.columns < 3}"></div>
       <!--template loaded here -->
       <div flex ui-view name="content"></div>

--- a/demo/portal/src/app/main.tpl.html
+++ b/demo/portal/src/app/main.tpl.html
@@ -21,7 +21,7 @@
         </md-list-item>
         <md-divider></md-divider>
 
-        <md-list-item ng-click="navigateTo('app.login')">
+        <md-list-item ng-click="logout()">
           <md-icon md-font-set="material-icons">exit_to_app</md-icon>
           <p>Logout</p>
         </md-list-item>

--- a/demo/portal/src/app/services/userService.js
+++ b/demo/portal/src/app/services/userService.js
@@ -1,6 +1,7 @@
 var Promise = require("bluebird");
 
-function UserService() {
+function UserService(authService) {
+  this.auth = authService;
 }
 
 UserService.prototype.readUser = function readUser() {
@@ -19,15 +20,27 @@ UserService.prototype.readUser = function readUser() {
 };
 
 
-UserService.prototype.getProfile = function(userId) {
-  return this.readUser(userId);
+UserService.prototype.getProfile = function getProfile() {
+  return this.auth.getProfile();
+};
+
+UserService.prototype.hasResourceRole = function hasResourceRole() {
+  return this.auth.hasResourceRole();
 };
 
 UserService.prototype.listUsers = function listUsers() {
   return Promise.all(this.readUser());
 };
 
+UserService.prototype.login = function login() {
+  return this.auth.login();
+};
 
-angular.module('wfm.common.apiservices').service("userService", function() {
-  return new UserService();
-});
+UserService.prototype.logout = function logout() {
+  return this.auth.logout();
+}
+
+
+angular.module('wfm.common.apiservices').service("userService", ['authService', function(authService) {
+  return new UserService(authService);
+}]);

--- a/demo/portal/src/app/services/userService.js
+++ b/demo/portal/src/app/services/userService.js
@@ -24,8 +24,8 @@ UserService.prototype.getProfile = function getProfile() {
   return this.auth.getProfile();
 };
 
-UserService.prototype.hasResourceRole = function hasResourceRole() {
-  return this.auth.hasResourceRole();
+UserService.prototype.hasResourceRole = function hasResourceRole(role) {
+  return this.auth.hasResourceRole(role);
 };
 
 UserService.prototype.listUsers = function listUsers() {

--- a/demo/portal/src/index.html
+++ b/demo/portal/src/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ng-app="app">
+<html>
   <head>
     <base href="./">
     <meta charset="utf-8">

--- a/packages/auth-passport/index.js
+++ b/packages/auth-passport/index.js
@@ -1,6 +1,8 @@
 angular.module('wfm.auth.passport', []);
 
 require('./authService');
-require('./initApp');
 
-module.exports = 'wfm.auth.passport';
+module.exports = function(appName) {
+  require('./initApp')(appName);
+  return 'wfm.auth.passport';
+}

--- a/packages/auth-passport/initApp.js
+++ b/packages/auth-passport/initApp.js
@@ -1,3 +1,7 @@
+/**
+ * Starts the specfied angular app once document is ready
+ * @param appName - The name of the app to be started
+ */
 module.exports = function (appName) {
   angular.element(document).ready(function() {
     angular.bootstrap(document, [appName]);

--- a/packages/auth-passport/initApp.js
+++ b/packages/auth-passport/initApp.js
@@ -1,3 +1,5 @@
-angular.element(document).ready(function() {
-  angular.bootstrap(document, ["wfm-mobile"]);
-});
+module.exports = function (appName) {
+  angular.element(document).ready(function() {
+    angular.bootstrap(document, [appName]);
+  });
+}

--- a/packages/dialog/.eslintrc
+++ b/packages/dialog/.eslintrc
@@ -1,0 +1,35 @@
+{
+  "env": {
+    "node": true,
+    "mocha": true
+  },
+  "extends": "eslint:recommended",
+  "rules": {
+    "array-callback-return": "warn",
+    "brace-style": ["error", "1tbs"],
+    "complexity": ["warn", 20],
+    "eqeqeq": "error",
+    "guard-for-in": "error",
+    "indent": ["error", 2],
+    "linebreak-style": ["error", "unix"],
+    "no-array-constructor": "error",
+    "no-console": "warn",
+    "no-lonely-if": "warn",
+    "no-loop-func": "warn",
+    "no-mixed-spaces-and-tabs": ["error"],
+    "no-nested-ternary": "error",
+    "no-spaced-func": "error",
+    "no-trailing-spaces": "error",
+    "semi": ["error", "always"],
+    "space-before-blocks": "error",
+    "space-before-function-paren": ["error", "never"],
+    "keyword-spacing": ["error"],
+    "curly": ["error", "all"]
+  },
+  "globals": {
+    "angular": false,
+    "window": true,
+    "inject": true
+  }
+}
+

--- a/packages/dialog/dialog.js
+++ b/packages/dialog/dialog.js
@@ -10,6 +10,6 @@ DialogService.prototype.showConfirm = function showConfirm(confirmContent) {
   return this.mdDialog.show(this.mdDialog.confirm(confirmContent));
 };
 
-angular.module('wfm.common.util').service('dialogService', ['$mdDialog', function($mdDialog) {
+angular.module('wfm.util.dialog').service('dialogService', ['$mdDialog', function($mdDialog) {
   return new DialogService($mdDialog);
 }]);

--- a/packages/dialog/index.js
+++ b/packages/dialog/index.js
@@ -1,0 +1,5 @@
+angular.module('wfm.util.dialog', []);
+
+require('./dialog');
+
+module.exports = 'wfm.util.dialog';

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@raincatcher/dialog",
+  "version": "1.0.0",
+  "description": "A dialog utility service which utilizes angular-material's mdDialog",
+  "engines": {
+    "node": ">=4.4 <=6.10"
+  },
+  "keywords": [
+    "wfm"
+  ],
+  "license": "MIT",
+  "author": "feedhenry-raincatcher@redhat.com",
+  "dependencies": {
+    "@raincatcher/logger": "1.0.0",
+    "angular": "1.6.1",
+    "fh-js-sdk": "2.18.6"
+  },
+  "devDependencies": {
+    "browserify": "^14.4.0",
+    "browserify-shim": "^3.8.14"
+  }
+}


### PR DESCRIPTION
## Motivation
The demo portal application will requires som form of authentication. Passport.js will be needed to be itnegrated with the demo solution as the default auth service. 

## Description
Integration of the Passport auth module with the demo portal application. This will also include the integration of the dialog service module which is utilized by Passport Auth module. 

## Progress
- [x] Allow specifiying the application's angular app name which is required by angular bootstrap for starting the application.
- [x] Move the dialogService implementation from the mobile application to a separate module which can be utilized by both the portal and mobile application.
- [x] Integrate the passport auth and dialog service module with the portal app

## Additional Notes
Related JIRA - https://issues.jboss.org/browse/RAINCATCH-1110
