### PR TITLE
remove demo-wfm from being required as a module in portal

### DIFF
--- a/demo/portal/src/app/main.js
+++ b/demo/portal/src/app/main.js
@@ -12,7 +12,6 @@ angular.module('app', [
   require('@raincatcher/dialog'),
   require('@raincatcher/demo-auth-passport')('app'),
   require('./services'),
-  require('@raincatcher/demo-wfm'),
   require('@raincatcher/demo-http'),
   require('ng-sortable'),
   require('./feedhenry'),


### PR DESCRIPTION
Portal is failing to start due to unavailable demo-wfm module being required in the app main.
