### PR TITLE
[RAINCATCH 1169] Reduce data needed from http requests

### DIFF
--- a/packages/http/configCache.js
+++ b/packages/http/configCache.js
@@ -1,0 +1,4 @@
+angular.module('wfm.http').config(['$httpProvider',
+  function($httpProvider) {
+    $httpProvider.defaults.cache = true;
+  }]);

--- a/packages/http/index.js
+++ b/packages/http/index.js
@@ -1,5 +1,6 @@
 angular.module('wfm.http', []);
 
+require('./configCache');
 require('./httpServices');
 require('./baseUrl');
 

--- a/packages/workflow-angular/lib/services/flow-service.js
+++ b/packages/workflow-angular/lib/services/flow-service.js
@@ -10,13 +10,11 @@ angular.module(CONSTANTS.WORKFLOW_DIRECTIVE_MODULE).service(CONSTANTS.WORKFLOW_F
   flowService.goToWorkflowDetails = function(workflow) {
     $state.go('app.workflow.detail', {
       workflowId: workflow.id
-    },
-      { reload: true }
-    );
+    });
   };
   //Want to display the list of workflows.
   flowService.goToWorkflowList = function() {
-    $state.go('app.workflow', null, { reload: false });
+    $state.go('app.workflow');
   };
   return flowService;
 }).filter('isEmpty', function() {

--- a/packages/workorder-angular/dist/workorder-list.tpl.html.js
+++ b/packages/workorder-angular/dist/workorder-list.tpl.html.js
@@ -27,7 +27,7 @@ ngModule.run(['$templateCache', function ($templateCache) {
     '    ng-class="{active: ctrl.selected.id === workorder.id}"\n' +
     '    class="md-2-line workorder-item"\n' +
     '  >\n' +
-    '  <workorder-status ng-class="ctrl.getColorIcon(workorder)" status="ctrl.resultMap[workorder.id].status"></workorder-status>\n' +
+    '  <workorder-status ng-class="ctrl.getColorIcon(workorder)" status="workorder.status"></workorder-status>\n' +
     '\n' +
     '    <div class="md-list-item-text">\n' +
     '      <h3>{{workorder.title}}</h3>\n' +

--- a/packages/workorder-angular/lib/services/api-service.js
+++ b/packages/workorder-angular/lib/services/api-service.js
@@ -49,6 +49,11 @@ WorkorderApiService.prototype.listUsers = function() {
   return this.userService.listUsers();
 };
 
+
+WorkorderApiService.prototype.getResultByWorkorder = function(workorderId) {
+  return this.resultService.readByWorkorder(workorderId);
+};
+
 WorkorderApiService.prototype.subscribeToListUpdated = function() {
   // TODO sync streams
 };

--- a/packages/workorder-angular/lib/services/flow-service.js
+++ b/packages/workorder-angular/lib/services/flow-service.js
@@ -11,8 +11,7 @@ angular.module(CONSTANTS.WORKORDER_DIRECTIVE).service(CONSTANTS.WORKORDER_FLOW_S
       if (WORKORDER_CONFIG.adminMode) {
         $state.go(
           'app.workorder.summary',
-          { workorderId: workorder.id },
-          { reload: true }
+          { workorderId: workorder.id }
         );
       } else {
         //In User mode, selecting the workorder means that we want to start the workflow.
@@ -23,7 +22,7 @@ angular.module(CONSTANTS.WORKORDER_DIRECTIVE).service(CONSTANTS.WORKORDER_FLOW_S
     }
 
     function listWorkorders() {
-      $state.go('app.workorder', null, { reload: true });
+      $state.go('app.workorder');
     }
 
     return {

--- a/packages/workorder-angular/lib/template/workorder-list.tpl.html
+++ b/packages/workorder-angular/lib/template/workorder-list.tpl.html
@@ -18,7 +18,7 @@
     ng-class="{active: ctrl.selected.id === workorder.id}"
     class="md-2-line workorder-item"
   >
-  <workorder-status ng-class="ctrl.getColorIcon(workorder)" status="ctrl.resultMap[workorder.id].status"></workorder-status>
+  <workorder-status ng-class="ctrl.getColorIcon(workorder)" status="workorder.status"></workorder-status>
 
     <div class="md-list-item-text">
       <h3>{{workorder.title}}</h3>

--- a/packages/workorder-angular/lib/workorder-detail/workorder-detail-controller.js
+++ b/packages/workorder-angular/lib/workorder-detail/workorder-detail-controller.js
@@ -6,21 +6,10 @@ var CONSTANTS = require('../constants');
  * @constructor
  */
 
-function WorkorderDetailController($state, WORKORDER_CONFIG, workorderStatusService, workorderFlowService) {
+function WorkorderDetailController($state, WORKORDER_CONFIG, workorderStatusService) {
   var self = this;
 
   self.adminMode = WORKORDER_CONFIG.adminMode;
-
-  self.selectWorkorder = function(event, workorder) {
-    if (workorder.id) {
-      workorderFlowService.workorderSelected(workorder);
-    } else {
-      workorderFlowService.listWorkorders();
-    }
-
-    event.preventDefault();
-    event.stopPropagation();
-  };
 
   self.getColorIcon = function(status) {
     return workorderStatusService.getStatusIconColor(status).statusColor;

--- a/packages/workorder-angular/lib/workorder-list/workorder-list-controller.js
+++ b/packages/workorder-angular/lib/workorder-list/workorder-list-controller.js
@@ -11,13 +11,12 @@ function WorkorderListController($scope, workorderApiService, workorderFlowServi
   var _workorders = [];
 
   self.workorders = [];
-  self.resultMap = {};
 
   function refreshWorkorderData() {
-    $q.all([workorderApiService.listWorkorders(), workorderApiService.resultMap()]).then(function(results) {
-      self.workorders = results[0];
-      _workorders = results[0];
-      self.resultMap = results[1];
+    // Needs $q.when to trigger angular's change detection
+    $q.when(workorderApiService.listWorkorders()).then(function(workorders) {
+      self.workorders = workorders;
+      _workorders = workorders;
     });
   }
 
@@ -45,11 +44,10 @@ function WorkorderListController($scope, workorderApiService, workorderFlowServi
   };
 
   self.getColorIcon = function(workorder) {
-    var result = this.resultMap[workorder.id];
-    if (!result) {
+    if (!workorder || !workorder.status) {
       return workorderStatusService.getStatusIconColor('').statusColor;
     } else {
-      return workorderStatusService.getStatusIconColor(this.resultMap[workorder.id].status).statusColor;
+      return workorderStatusService.getStatusIconColor(workorder.status).statusColor;
     }
   };
 }

--- a/packages/workorder-angular/lib/workorder-summary/workorder-summary-controller.js
+++ b/packages/workorder-angular/lib/workorder-summary/workorder-summary-controller.js
@@ -16,14 +16,10 @@ function WorkorderSummaryController($scope, $mdDialog, $state, $stateParams, wor
       return workorderApiService.readWorkflow(workorder.workflowId);
     });
 
-    var resultPromise = workorderPromise.then(function(workorder) {
-      return $q.when(workorderApiService.resultMap().then(function(resultMap) {
-        return resultMap[workorder.id];
-      }));
-    });
+    var resultPromise = workorderApiService.getResultByWorkorder(workorderId);
 
     var workerPromise = workorderPromise.then(function(workorder) {
-      return workorder && workorder.assignee ? workorderApiService.readUser(workorder.assignee) : $q.when(null);
+      return workorder && workorder.assignee ? workorderApiService.readUser(workorder.assignee) : null;
     });
     //TODO: Error handling
     $q.all([workorderPromise, workflowPromise, resultPromise, workerPromise])


### PR DESCRIPTION
## Motivation
Client was often requesting the entire results collection and filtering locally.

## Description
Use status field from workorder to avoid extra data entity hop. This field wasn't being updated before, so needs the linked pr with changes to the wfm service to work.
Add caching to the http service, this could be moved to the demo application's configuration instead, giving more control.

## Progress
- [X] Remove resultMap usage from controllers and views
- [X] Add caching to $http

## Additional Notes
Verified locally once, but demo-server data started getting weird and not showing up on the mobile app via sync with the user 'trever'