### PR TITLE
An error occurs when calling sync's removeManagers function

### DIFF
--- a/packages/sync/syncGlobalManager.js
+++ b/packages/sync/syncGlobalManager.js
@@ -25,7 +25,7 @@ function initSync($http) {
       }
       var cloudUrl = decodeURIComponent($fh.getCloudURL());
       var handler = syncGlobalNetworkHandler(cloudUrl, config.cloudPath, $http);
-      syncApi.setCloudHandler(handler);
+      //syncApi.setCloudHandler(handler);
       initializeGlobalSync(cloudUrl);
     });
 

--- a/packages/sync/syncPoolService.js
+++ b/packages/sync/syncPoolService.js
@@ -11,11 +11,15 @@ var syncManagers;
  * Remove synchronization managers
  */
 syncPool.removeManagers = function() {
-  return Promise.map(syncManagers, function(syncManager) {
-    return syncManager.stop();
-  }).then(function() {
-    syncManagers = null;
-  });
+  if (syncManagers) {
+    return Promise.map(syncManagers, function(syncManager) {
+      return syncManager.stop();
+    }).then(function() {
+      syncManagers = null;
+    });
+  } else {
+    return Promise.resolve();
+  }
 };
 
 /**
@@ -41,7 +45,7 @@ syncPool.syncManagerMap = function(profileData) {
   ]).then(function(managers) {
     managers.forEach(function(syncDatasetManager) {
       syncManagers[syncDatasetManager.datasetId] = syncDatasetManager;
-      syncDatasetManager.start(function() {}); //start sync for this dataset
+      syncDatasetManager.start(function() { }); //start sync for this dataset
     });
     return syncManagers;
   });

--- a/packages/workflow-angular/dist/workflow-form.tpl.html.js
+++ b/packages/workflow-angular/dist/workflow-form.tpl.html.js
@@ -11,7 +11,7 @@ ngModule.run(['$templateCache', function ($templateCache) {
     '\n' +
     '  <md-toolbar class="content-toolbar md-primary">\n' +
     '    <div class="md-toolbar-tools">\n' +
-    '      <h3>{{(ctrl.model.id) ? \'Update\' : \'Create\'}} workflow</h3>\n' +
+    '      <h3>{{ctrl.model.id ? \'Update\' : \'Create\'}} workflow</h3>\n' +
     '      <span flex></span>\n' +
     '      <md-button class="md-icon-button" aria-label="Close" ng-click="ctrl.selectWorkflow($event, ctrl.model)">\n' +
     '        <md-icon md-font-set="material-icons">close</md-icon>\n' +

--- a/packages/workflow-angular/dist/workflow-list.tpl.html.js
+++ b/packages/workflow-angular/dist/workflow-list.tpl.html.js
@@ -22,7 +22,7 @@ ngModule.run(['$templateCache', function ($templateCache) {
     '\n' +
     '<md-list ng-if="ctrl.workflows">\n' +
     '  <md-list-item ng-repeat="workflow in ctrl.workflows" ng-click="ctrl.selectWorkflow($event, workflow)"\n' +
-    '                ng-class="{active: selected.id === workflow.id }" >\n' +
+    '                ng-class="{active: selected.id === workflow.id}" >\n' +
     '    <div class="md-list-item-text">\n' +
     '      <p>\n' +
     '        {{workflow.title}} <br/>\n' +


### PR DESCRIPTION
## Motivation

After investigation I do not see removeManagers being called anymore. 
Depending on how mobile security will be implemented we may actually need it. 
I have made fix to prevent from that issue in the future, but this will happen only when page will get immediate redirect after being loaded.