### PR TITLE
Remove cordova plugins from package.json

### DIFF
--- a/demo/mobile/package.json
+++ b/demo/mobile/package.json
@@ -41,18 +41,7 @@
     "q": "1.5.0",
     "rx": "~4.1.0",
     "shortid": "~2.2.6",
-    "underscore": "~1.8.3",
-    "cordova-plugin-camera": "~2.3.0",
-    "cordova-plugin-console": "~1.0.3",
-    "cordova-plugin-device": "~1.1.2",
-    "cordova-plugin-file": "~4.2.0",
-    "cordova-plugin-file-transfer": "~1.5.1",
-    "cordova-plugin-geolocation": "~2.4.0",
-    "cordova-plugin-inappbrowser": "1.6.1",
-    "cordova-plugin-network-information": "~1.2.1",
-    "cordova-plugin-splashscreen": "~4.0.0",
-    "cordova-plugin-whitelist": "~1.2.2",
-    "phonegap-plugin-barcodescanner": "~6.0.0"
+    "underscore": "~1.8.3"
   },
   "devDependencies": {
     "browserify": "13.3.0",
@@ -71,24 +60,5 @@
     "load-grunt-tasks": "3.4.1",
     "time-grunt": "1.3.0",
     "uglifyify": "~3.0.4"
-  },
-  "cordova": {
-    "platforms": [
-      "android",
-      "ios"
-    ],
-    "plugins": {
-      "cordova-plugin-camera": {},
-      "cordova-plugin-console": {},
-      "cordova-plugin-device": {},
-      "cordova-plugin-file": {},
-      "cordova-plugin-file-transfer": {},
-      "cordova-plugin-geolocation": {},
-      "cordova-plugin-inappbrowser": {},
-      "cordova-plugin-network-information": {},
-      "cordova-plugin-splashscreen": {},
-      "cordova-plugin-whitelist": {},
-      "phonegap-plugin-barcodescanner": {}
-    }
   }
 }


### PR DESCRIPTION
## Motivation

Removing cordova generate builds for the moment as they aren't compatible between node versions. Cordova adding all this details on `cordova prepare` so we do not need them for non cordova based environments.