### PR TITLE
RAINCATCH-1188 - sync datahandler is not sending response

### DIFF
--- a/demo/mobile/src/app/sync/syncGlobalManager.js
+++ b/demo/mobile/src/app/sync/syncGlobalManager.js
@@ -22,8 +22,8 @@ function initSync($http) {
         return reject(error);
       }
       var cloudUrl = decodeURIComponent($fh.getCloudURL());
-      syncGlobalNetworkHandler(cloudUrl, config.cloudPath, $http);
-      //syncApi.setCloudHandler(handler);
+      var handler = syncGlobalNetworkHandler(cloudUrl, config.cloudPath, $http);
+      syncApi.setCloudHandler(handler);
       initializeGlobalSync(cloudUrl);
     });
 

--- a/demo/mobile/src/app/sync/syncGlobalNetworkHandler.js
+++ b/demo/mobile/src/app/sync/syncGlobalNetworkHandler.js
@@ -2,7 +2,7 @@ module.exports = function createHandler(cloudURL, cloudPath, $http) {
   var handler = function(params, success, failure) {
     var url = cloudURL + cloudPath + params.dataset_id;
     var payload = params.req;
-    $http.post(url, payload, {}).then(function(response) {
+    $http.post(url, payload).then(function(response) {
       success(response.data);
     }).catch(function(err) {
       failure(new Error(err));

--- a/demo/mobile/src/app/sync/syncGlobalNetworkHandler.js
+++ b/demo/mobile/src/app/sync/syncGlobalNetworkHandler.js
@@ -2,7 +2,11 @@ module.exports = function createHandler(cloudURL, cloudPath, $http) {
   var handler = function(params, success, failure) {
     var url = cloudURL + cloudPath + params.dataset_id;
     var payload = params.req;
-    $http.post(url, payload, {}).then(success).catch(failure);
+    $http.post(url, payload, {}).then(function(response) {
+      success(response.data);
+    }).catch(function(err) {
+      failure(new Error(err));
+    });
   };
   return handler;
 };

--- a/demo/mobile/src/config.json
+++ b/demo/mobile/src/config.json
@@ -8,7 +8,8 @@
     "cloudPath": "/sync/",
     "syncOptions": {
       "global": {
-        "sync_frequency": 20
+        "sync_frequency": 20,
+        "storage_strategy": "dom"
       },
       "workorders": {
         "sync_frequency": 10


### PR DESCRIPTION
## Motivation

Change handler to fetch data when using secured sync endpoint.

## Verification

1. Remove database
1. Clean client cache and localstorage
1. Start server
1. Login as trever
1. Wait for workorders to appear.