### PR TITLE
[RAINCATCH-1245] Remove google maps api

### DIFF
--- a/demo/mobile/config.xml
+++ b/demo/mobile/config.xml
@@ -10,7 +10,6 @@
     <content src="index.html" />
     <access origin="*" />
     <access origin="https://fonts.googleapis.com" />
-    <access origin="https://maps.googleapis.com" />
     <access origin="https://*.gstatic.com" />
     <access origin="https://*.amazonaws.com" />
     <preference name="webviewbounce" value="false" />

--- a/demo/mobile/src/index.html
+++ b/demo/mobile/src/index.html
@@ -21,7 +21,6 @@
     <!-- your app's js -->
     <script src="app/vendor.js"></script>
     <script src="app/bundle.js"></script>
-    <script src='https://maps.googleapis.com/maps/api/js?v=3.exp'></script>
   </head>
   <body layout="column" class="wfm-mobile">
     <!-- <div ng-if="!ready" flex layout="row" layout-align="center center" class="spinner-overlay">


### PR DESCRIPTION
## Motivation
Mobile is no longer using google maps. When offline, this is breaking and leaving unnecessary error logs. 

## Description
Remove google maps api from the mobile app

## Progress
- [x] Remove google maps api

## Additional Notes
JIRA - https://issues.jboss.org/browse/RAINCATCH-1245
