### PR TITLE
[RAINCATCH-1238] Add missing exit button on workorder summary

### DIFF
--- a/demo/mobile/src/app/app.js
+++ b/demo/mobile/src/app/app.js
@@ -21,7 +21,8 @@ angular.module('wfm-mobile', [
   // Set of the data services
   require('@raincatcher/angularjs-workflow')({
     mode: "user",
-    mainColumnViewId: "content@app"
+    mainColumnViewId: "content@app",
+    toolbarViewId: "toolbar@app"
   }),
   require('@raincatcher/angularjs-workorder')({
     mode: "user",

--- a/packages/angularjs-workflow/lib/workflow-process/workflow-process-parent/workflow-process-toolbar-controller.js
+++ b/packages/angularjs-workflow/lib/workflow-process/workflow-process-parent/workflow-process-toolbar-controller.js
@@ -9,7 +9,7 @@ var CONSTANTS = require('../../constants');
  * @param workorderService
  * @constructor
  */
-function WorkflowProcessToolbarController($scope, $stateParams, workorderService, workflowFlowService) {
+function WorkflowProcessToolbarController($scope, $stateParams, workorderService, $state) {
   var workorderId = $stateParams.workorderId;
 
   workorderService.read(workorderId).then(function(workorder) {
@@ -18,9 +18,9 @@ function WorkflowProcessToolbarController($scope, $stateParams, workorderService
 
   //Want to close this workflow and switch back to the list of workorders
   $scope.close = function() {
-    workflowFlowService.goToWorkflowList();
+    $state.go('app.workorder');
   };
 }
 
-angular.module(CONSTANTS.WORKFLOW_DIRECTIVE_MODULE).controller('ProcessToolbarController', ['$scope', '$stateParams', 'workorderService', 'workflowFlowService', WorkflowProcessToolbarController]);
+angular.module(CONSTANTS.WORKFLOW_DIRECTIVE_MODULE).controller('ProcessToolbarController', ['$scope', '$stateParams', 'workorderService', '$state', WorkflowProcessToolbarController]);
 


### PR DESCRIPTION
## Motivation
There is no way of exiting back from the workorder when a workorder is selected.

## Description
Add missing exit button to the workorder summary once a workorder has been selected to allow users to exit from it. 

## Progress
- [x] Add missing exit button to the workorder summary

## Additional Notes
Related JIRA - https://issues.jboss.org/browse/RAINCATCH-1238
