### PR TITLE
[RAINCATCH-1232] More fixes for app publishing flow

### DIFF
--- a/demo/mobile/package.json
+++ b/demo/mobile/package.json
@@ -7,6 +7,7 @@
   },
   "scripts": {
     "start": "grunt",
+    "build": "grunt build",
     "test": "grunt eslint"
   },
   "keywords": [

--- a/demo/portal/package.json
+++ b/demo/portal/package.json
@@ -7,7 +7,8 @@
   },
   "main": "application.js",
   "scripts": {
-    "start": "grunt"
+    "start": "grunt",
+    "build": "grunt build"
   },
   "keywords": [
     "wfm"

--- a/lerna.json
+++ b/lerna.json
@@ -10,19 +10,10 @@
   "commands": {
     "publish": {
       "exact": true,
-      "scope": [
-        "@raincatcher/angularjs-auth-keycloak",
-        "@raincatcher/angularjs-auth-passport",
-        "@raincatcher/angularjs-auth",
-        "@raincatcher/angularjs-http",
-        "@raincatcher/vehicle-inspection",
-        "@raincatcher/angularjs-workflow",
-        "@raincatcher/angularjs-workorder",
-        "@raincatcher/demo-mobile",
-        "@raincatcher/demo-portal",
-        "@raincatcher/step-signature",
-        "@raincatcher-examples/step-accident",
-        "@raincatcher-examples/step-vehicle-inspection"
+      "ignore": [
+        "@raincatcher/wfm",
+        "@raincatcher/logger",
+        "@raincatcher/datasync-client"
       ]
     }
   },

--- a/lerna.json
+++ b/lerna.json
@@ -13,12 +13,14 @@
       "scope": [
         "@raincatcher/angularjs-auth-keycloak",
         "@raincatcher/angularjs-auth-passport",
+        "@raincatcher/angularjs-auth",
         "@raincatcher/angularjs-http",
         "@raincatcher/vehicle-inspection",
         "@raincatcher/angularjs-workflow",
         "@raincatcher/angularjs-workorder",
         "@raincatcher/demo-mobile",
         "@raincatcher/demo-portal",
+        "@raincatcher/step-signature",
         "@raincatcher-examples/step-accident",
         "@raincatcher-examples/step-vehicle-inspection"
       ]


### PR DESCRIPTION
## Motivation
Upon start of platform tests, the contents of the generated www/ folders were out of date.
Also, a couple of the new modules were not included in the script for publishing to npm.

## Description
- Add `npm run build` scripts for the demo apps so that they're run when publishing
- Replace fixed scope for `lerna publish` with just ignoring the linked modules from core
