### PR TITLE
[RAINCATCH-623] Clear sync cache on logout

### DIFF
--- a/demo/mobile/src/app/sync/syncGlobalManager.js
+++ b/demo/mobile/src/app/sync/syncGlobalManager.js
@@ -43,9 +43,15 @@ SyncManager.prototype.manageDataset = function(datasetId, options, queryParams, 
  */
 SyncManager.prototype.removeManagers = function() {
   if (this.syncManagers) {
-    return Promise.map(this.syncManagers, m => m.safeStop()
-      .then(() => m.clearCache())
-      .then(() => this.syncManagers = []));
+    return Promise.map(this.syncManagers, function(syncManager) {
+      syncManager.safeStop()
+        .then(function() {
+          syncManager.clearCache();
+        })
+        .then(function() {
+          this.syncManagers = [];
+        });
+    });
   }
   return Promise.resolve();
 };

--- a/demo/mobile/src/app/sync/syncGlobalManager.js
+++ b/demo/mobile/src/app/sync/syncGlobalManager.js
@@ -44,7 +44,9 @@ SyncManager.prototype.manageDataset = function(datasetId, options, queryParams, 
 SyncManager.prototype.removeManagers = function() {
   if (this.syncManagers) {
     this.syncManagers.forEach(function(syncDatasetManager) {
-      syncDatasetManager.safeStop(); //stop sync for this dataset
+      syncDatasetManager.safeStop().then(function() {
+        syncDatasetManager.clearCache(); //clear cache for this dataset
+      }); //stop sync for this dataset
     });
     this.syncManagers = [];
   }

--- a/demo/mobile/src/app/sync/syncGlobalManager.js
+++ b/demo/mobile/src/app/sync/syncGlobalManager.js
@@ -43,12 +43,9 @@ SyncManager.prototype.manageDataset = function(datasetId, options, queryParams, 
  */
 SyncManager.prototype.removeManagers = function() {
   if (this.syncManagers) {
-    this.syncManagers.forEach(function(syncDatasetManager) {
-      syncDatasetManager.safeStop().then(function() {
-        syncDatasetManager.clearCache(); //clear cache for this dataset
-      }); //stop sync for this dataset
-    });
-    this.syncManagers = [];
+    return Promise.map(this.syncManagers, m => m.safeStop()
+      .then(() => m.clearCache())
+      .then(() => this.syncManagers = []));
   }
   return Promise.resolve();
 };

--- a/demo/mobile/src/app/sync/syncGlobalManager.js
+++ b/demo/mobile/src/app/sync/syncGlobalManager.js
@@ -33,7 +33,7 @@ SyncManager.prototype.manageDataset = function(datasetId, options, queryParams, 
       if (err) {
         return reject(err);
       }
-      resolve();
+      return resolve();
     });
   });
 };


### PR DESCRIPTION
## Motivation
In the mobile app, the previous logged in user's data is shown upon login. We need to clear sync cache to prevent this. 

## Description
Utilize clearCache() upon logout

## Progress
- [x] Use clearCache upon logout to remove sync data.

## Additional Notes
Related JIRA - https://issues.jboss.org/browse/RAINCATCH-623
