### PR TITLE
RAINCATCH-1261 Dragging steps in UI removes them

### DIFF
--- a/packages/angularjs-workflow/dist/workflow-detail.tpl.html.js
+++ b/packages/angularjs-workflow/dist/workflow-detail.tpl.html.js
@@ -35,7 +35,7 @@ ngModule.run(['$templateCache', function ($templateCache) {
     '        </md-button>\n' +
     '        <md-button class="md-icon-button" aria-label="Delete Step"\n' +
     '                   ng-click="ctrl.deleteStep($event, step, $index, ctrl.workflow)">\n' +
-    '          <md-icon md-font-set="material-icons">delete step</md-icon>\n' +
+    '          <md-icon md-font-set="material-icons">delete sweep</md-icon>\n' +
     '        </md-button>\n' +
     '      </md-card-actions>\n' +
     '    </md-card>\n' +

--- a/packages/angularjs-workflow/dist/workflow-detail.tpl.html.js
+++ b/packages/angularjs-workflow/dist/workflow-detail.tpl.html.js
@@ -24,7 +24,7 @@ ngModule.run(['$templateCache', function ($templateCache) {
     '\n' +
     '<div class="wfm-maincol-scroll" ng-if="ctrl.workflow">\n' +
     '  <div id="stepList" ng-model="ctrl.workflow.steps" as-sortable="ctrl.dragControlListeners">\n' +
-    '    <md-card ng-repeat="step in ctrl.workflow.steps track by $index"  as-sortable-item>\n' +
+    '    <md-card ng-repeat="step in ctrl.workflow.steps track by $index"  ng-model="step" as-sortable-item>\n' +
     '      <md-card-content as-sortable-item-handle>\n' +
     '        <workflow-step-detail step="step"></workflow-step-detail>\n' +
     '      </md-card-content>\n' +
@@ -35,7 +35,7 @@ ngModule.run(['$templateCache', function ($templateCache) {
     '        </md-button>\n' +
     '        <md-button class="md-icon-button" aria-label="Delete Step"\n' +
     '                   ng-click="ctrl.deleteStep($event, step, $index, ctrl.workflow)">\n' +
-    '          <md-icon md-font-set="material-icons">delete sweep</md-icon>\n' +
+    '          <md-icon md-font-set="material-icons">delete step</md-icon>\n' +
     '        </md-button>\n' +
     '      </md-card-actions>\n' +
     '    </md-card>\n' +

--- a/packages/angularjs-workflow/lib/template/workflow-detail.tpl.html
+++ b/packages/angularjs-workflow/lib/template/workflow-detail.tpl.html
@@ -26,7 +26,7 @@
         </md-button>
         <md-button class="md-icon-button" aria-label="Delete Step"
                    ng-click="ctrl.deleteStep($event, step, $index, ctrl.workflow)">
-          <md-icon md-font-set="material-icons">delete step</md-icon>
+          <md-icon md-font-set="material-icons">delete sweep</md-icon>
         </md-button>
       </md-card-actions>
     </md-card>

--- a/packages/angularjs-workflow/lib/template/workflow-detail.tpl.html
+++ b/packages/angularjs-workflow/lib/template/workflow-detail.tpl.html
@@ -15,7 +15,7 @@
 
 <div class="wfm-maincol-scroll" ng-if="ctrl.workflow">
   <div id="stepList" ng-model="ctrl.workflow.steps" as-sortable="ctrl.dragControlListeners">
-    <md-card ng-repeat="step in ctrl.workflow.steps track by $index"  as-sortable-item>
+    <md-card ng-repeat="step in ctrl.workflow.steps track by $index"  ng-model="step" as-sortable-item>
       <md-card-content as-sortable-item-handle>
         <workflow-step-detail step="step"></workflow-step-detail>
       </md-card-content>
@@ -26,7 +26,7 @@
         </md-button>
         <md-button class="md-icon-button" aria-label="Delete Step"
                    ng-click="ctrl.deleteStep($event, step, $index, ctrl.workflow)">
-          <md-icon md-font-set="material-icons">delete sweep</md-icon>
+          <md-icon md-font-set="material-icons">delete step</md-icon>
         </md-button>
       </md-card-actions>
     </md-card>

--- a/packages/angularjs-workflow/lib/workflow-detail/workflow-detail-controller.js
+++ b/packages/angularjs-workflow/lib/workflow-detail/workflow-detail-controller.js
@@ -20,6 +20,9 @@ function WorkflowDetailController($scope, $mdDialog, $stateParams, workflowServi
   //Used with the ng-sortable module
   self.dragControlListeners = {
     containment: '#stepList',
+    accept: function(sourceItemHandleScope, destSortableScope) {
+      return sourceItemHandleScope.itemScope.sortableScope.$id === destSortableScope.$id;
+    },
     orderChanged :  function() {
       workflowService.update(self.workflow);
     }


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/RAINCATCH-1261
steps were deleted when dragged onto another step or to the side.

## Description

## Progress
- [x] added `accept` handler to disable horizontal drag
- [x] fixed delete bug

