### PR TITLE
[RAINCATCH-1225] Refresh data lists

### DIFF
--- a/packages/angularjs-http/lib/httpServices.js
+++ b/packages/angularjs-http/lib/httpServices.js
@@ -6,6 +6,8 @@ var datasets = {
   results: "results"
 };
 
+// These services must be singletons to allow for event listeners to be global
+// i.e. workorderService.onBeforeCreate, etc.
 var workorderService;
 var workflowService;
 

--- a/packages/angularjs-http/lib/httpServices.js
+++ b/packages/angularjs-http/lib/httpServices.js
@@ -1,6 +1,3 @@
-var _ = require('lodash');
-
-// Generating common data repositories
 var HttpApiDataService = require("./httpDataService");
 
 var datasets = {
@@ -8,9 +5,19 @@ var datasets = {
   workflows: "workflows",
   results: "results"
 };
+
+var workorderService;
+var workflowService;
+
 angular.module('wfm.common.apiservices').service("workorderService", ['baseUrl', '$http', function(baseUrlPromise, $http) {
-  return new HttpApiDataService(datasets.workorders, baseUrlPromise, $http);
+  if (!workorderService) {
+    workorderService = new HttpApiDataService(datasets.workorders, baseUrlPromise, $http);
+  }
+  return workorderService;
 }]);
 angular.module('wfm.common.apiservices').service("workflowService", ['baseUrl', '$http', function(baseUrlService, $http) {
-  return new HttpApiDataService(datasets.workflows, baseUrlService, $http);
+  if (!workflowService) {
+    return new HttpApiDataService(datasets.workflows, baseUrlService, $http);
+  }
+  return workflowService;
 }]);

--- a/packages/angularjs-workflow/lib/workflow-list/workflow-list-controller.js
+++ b/packages/angularjs-workflow/lib/workflow-list/workflow-list-controller.js
@@ -61,7 +61,7 @@ function WorkflowListController($scope, $stateParams, workflowService, workflowF
     self.updateFilter();
   };
 
-  self.updateFilter = function() {
+  self.updateFilter = _.debounce(function() {
     $scope.$apply(function() {
       if (!self.term) {
         return self.workflows = _workflows;
@@ -72,7 +72,7 @@ function WorkflowListController($scope, $stateParams, workflowService, workflowF
           || String(workflow.id).indexOf(term) !== -1;
       });
     });
-  };
+  }, 300);
 }
 
 angular.module(CONSTANTS.WORKFLOW_DIRECTIVE_MODULE).controller('WorkflowListController', ['$scope', '$stateParams', 'workflowService', 'workflowFlowService', WorkflowListController]);

--- a/packages/angularjs-workflow/lib/workflow-list/workflow-list-controller.js
+++ b/packages/angularjs-workflow/lib/workflow-list/workflow-list-controller.js
@@ -1,4 +1,5 @@
 var CONSTANTS = require('../constants');
+var _ = require('lodash');
 
 /**
  *
@@ -10,19 +11,41 @@ var CONSTANTS = require('../constants');
  * @param $timeout
  * @constructor
  */
-function WorkflowListController($scope, $stateParams, workflowService, workflowFlowService, $timeout) {
+function WorkflowListController($scope, $stateParams, workflowService, workflowFlowService) {
   var self = this;
-  self.workflows = null;
   self.selectedWorkflowId = $stateParams.workflowId;
+
+  // full list of workflows
   var _workflows;
+  // filtered list of workflows for display
+  self.workflows = null;
+
+  workflowService.on('create', function(workflow) {
+    _workflows.push(workflow);
+    self.updateFilter();
+  });
+
+  workflowService.on('remove', function(workflow) {
+    _.remove(_workflows, function(w) {
+      return w.id === workflow.id;
+    });
+    self.updateFilter();
+  });
+
+  workflowService.on('update', function(workflow) {
+    var idx = _.findIndex(_workflows, function(w) {
+      return w.id === workflow.id;
+    });
+
+    _workflows.splice(idx, 1, workflow);
+    self.updateFilter();
+  });
 
 
   function refreshWorkflows() {
     workflowService.list().then(function(workflows) {
-      $timeout(function() {
-        _workflows = workflows;
-        self.workflows = workflows;
-      });
+      _workflows = workflows;
+      self.updateFilter();
     });
   }
 
@@ -34,12 +57,22 @@ function WorkflowListController($scope, $stateParams, workflowService, workflowF
   };
 
   self.applyFilter = function(term) {
-    term = term.toLowerCase();
-    self.workflows = _workflows.filter(function(workflow) {
-      return String(workflow.title).toLowerCase().indexOf(term) !== -1
-        || String(workflow.id).indexOf(term) !== -1;
+    self.term = term;
+    self.updateFilter();
+  };
+
+  self.updateFilter = function() {
+    $scope.$apply(function() {
+      if (!self.term) {
+        return self.workflows = _workflows;
+      }
+      var term = self.term.toLowerCase();
+      self.workflows = _workflows.filter(function(workflow) {
+        return String(workflow.title).toLowerCase().indexOf(term) !== -1
+          || String(workflow.id).indexOf(term) !== -1;
+      });
     });
   };
 }
 
-angular.module(CONSTANTS.WORKFLOW_DIRECTIVE_MODULE).controller('WorkflowListController', [ '$scope',  '$stateParams', 'workflowService', 'workflowFlowService', '$timeout', WorkflowListController]);
+angular.module(CONSTANTS.WORKFLOW_DIRECTIVE_MODULE).controller('WorkflowListController', ['$scope', '$stateParams', 'workflowService', 'workflowFlowService', WorkflowListController]);

--- a/packages/angularjs-workorder/lib/workorder-list/workorder-list-controller.js
+++ b/packages/angularjs-workorder/lib/workorder-list/workorder-list-controller.js
@@ -10,47 +10,17 @@ var _ = require('lodash');
 function WorkorderListController($scope, workorderService, workorderFlowService, $q, workorderStatusService) {
   var self = this;
 
+  var _workorders = [];
   self.workorders = [];
 
-  function refreshWorkorderData() {
+  function refreshWorkorders() {
     // Needs $q.when to trigger angular's change detection
-    $q.when(workorderService.list()).then(function(workorders) {
-      self.workorders = workorders;
+    workorderService.list().then(function(workorders) {
+      _workorders = workorders;
+      self.updateFilter();
     });
   }
-  refreshWorkorderData();
-
-
-  workorderService.on('create', function(workorder) {
-    $scope.$apply(function() {
-      self.workorders.push(workorder);
-    });
-  });
-
-  workorderService.on('remove', function(workorder) {
-    $scope.$apply(function() {
-      _.remove(self.workorders, function(w) {
-        return w.id === workorder.id;
-      });
-    });
-  });
-
-  workorderService.on('update', function(workorder) {
-    $scope.$apply(function() {
-      var idx = _.findIndex(self.workorders, function(w) {
-        return w.id === workorder.id;
-      });
-
-      self.workorders.splice(idx, 1, workorder);
-    });
-  });
-
-  //Whenever the list is updated from the server, refresh the workorder list.
-  var subscribe = workorderService.subscribeToDatasetUpdates;
-  if (subscribe) {
-    var updateMethod = refreshWorkorderData.bind(self);
-    subscribe.bind(workorderService)(updateMethod);
-  }
+  refreshWorkorders();
 
   self.selectWorkorder = function(event, workorder) {
     workorderFlowService.workorderSelected(workorder);
@@ -58,26 +28,30 @@ function WorkorderListController($scope, workorderService, workorderFlowService,
     event.preventDefault();
     event.stopPropagation();
   };
+
   self.isWorkorderShown = function(workorder) {
     return self.shownWorkorder === workorder;
   };
 
   self.applyFilter = function(term) {
-    if (term.length === 0) {
-      refreshWorkorderData();
-    }
-
-    if (term.length > 3) {
-      var filter = {
-        id: term,
-        title: term
-      };
-
-      $q.resolve(workorderService.search(filter)).then(function(workorders) {
-        self.workorders = workorders;
-      });
-    }
+    self.term = term;
+    self.updateFilter();
   };
+
+  self.updateFilter = _.debounce(function() {
+    $scope.$apply(function() {
+      if (!self.term) {
+        return self.workorders = _workorders;
+      }
+      if (self.term.length > 3) {
+        var term = self.term.toLowerCase();
+        self.workorders = _workorders.filter(function(workflow) {
+          return String(workflow.title).toLowerCase().indexOf(term) !== -1
+            || String(workflow.id).indexOf(term) !== -1;
+        });
+      }
+    });
+  }, 300);
 
   self.getColorIcon = function(workorder) {
     if (!workorder || !workorder.status) {
@@ -86,6 +60,36 @@ function WorkorderListController($scope, workorderService, workorderFlowService,
       return workorderStatusService.getStatusIconColor(workorder.status).statusColor;
     }
   };
+
+  self.setupEventListenerHandlers = function() {
+    workorderService.on('create', function(workorder) {
+      _workorders.push(workorder);
+      self.updateFilter();
+    });
+
+    workorderService.on('remove', function(workorder) {
+      _.remove(_workorders, function(w) {
+        return w.id === workorder.id;
+      });
+      self.updateFilter();
+    });
+
+    workorderService.on('update', function(workorder) {
+      var idx = _.findIndex(_workorders, function(w) {
+        return w.id === workorder.id;
+      });
+
+      _workorders.splice(idx, 1, workorder);
+      self.updateFilter();
+    });
+  };
+
+  if (workorderService.on) {
+    self.setupEventListenerHandlers();
+  } else if (workorderService.subscribeToDatasetUpdates) {
+    // use the single method to update workorders via sync
+    workorderService.subscribeToDatasetUpdates(refreshWorkorders);
+  }
 }
 
 angular.module(CONSTANTS.WORKORDER_DIRECTIVE).controller('WorkorderListController', ['$scope', 'workorderService', 'workorderFlowService', '$q', 'workorderStatusService', WorkorderListController]);

--- a/packages/angularjs-workorder/lib/workorder-list/workorder-list-controller.js
+++ b/packages/angularjs-workorder/lib/workorder-list/workorder-list-controller.js
@@ -1,4 +1,5 @@
 var CONSTANTS = require('../constants');
+var _ = require('lodash');
 
 /**
  * Controller for listing Workorders
@@ -18,6 +19,31 @@ function WorkorderListController($scope, workorderService, workorderFlowService,
     });
   }
   refreshWorkorderData();
+
+
+  workorderService.on('create', function(workorder) {
+    $scope.$apply(function() {
+      self.workorders.push(workorder);
+    });
+  });
+
+  workorderService.on('remove', function(workorder) {
+    $scope.$apply(function() {
+      _.remove(self.workorders, function(w) {
+        return w.id === workorder.id;
+      });
+    });
+  });
+
+  workorderService.on('update', function(workorder) {
+    $scope.$apply(function() {
+      var idx = _.findIndex(self.workorders, function(w) {
+        return w.id === workorder.id;
+      });
+
+      self.workorders.splice(idx, 1, workorder);
+    });
+  });
 
   //Whenever the list is updated from the server, refresh the workorder list.
   var subscribe = workorderService.subscribeToDatasetUpdates;


### PR DESCRIPTION
## Motivation
List views in the portal app were no longer updating along with changes in the detail forms. Previous functionality relied on sync.

## Description
- Make data service into event emitter
- Subscribe to events from list views and update view data accordingly

## Progress
- [X] Data service event emitter inheritance
- [X] Workorder list view event listeners
- [X] Workflow list view event listeners
