### PR TITLE
RAINCATCH-1306 - Fix compilation issue

### DIFF
--- a/packages/angularjs-auth-keycloak/lib/authInterceptor.js
+++ b/packages/angularjs-auth-keycloak/lib/authInterceptor.js
@@ -2,7 +2,7 @@
 var q = require('q');
 
 // Global this
-let self;
+var self;
 
 /**
  * Keycloak angular auth interceptor.


### PR DESCRIPTION
## Motivation

`let` is not supported in all browsers and it should be avoided.