### PR TITLE
[RAINCATCH-1305] Remove sync cache on logout

### DIFF
--- a/demo/mobile/src/app/initialisation/config.js
+++ b/demo/mobile/src/app/initialisation/config.js
@@ -36,6 +36,7 @@ angular.module('wfm-mobile').config(['$stateProvider', '$urlRouterProvider', cre
     };
 
     $scope.logout = function() {
+      $scope.profileData = null;
       userService.logout();
     };
   }]);

--- a/demo/mobile/src/app/initialisation/config.js
+++ b/demo/mobile/src/app/initialisation/config.js
@@ -14,7 +14,7 @@ function createMainAppRoute($stateProvider, $urlRouterProvider) {
 
 angular.module('wfm-mobile').config(['$stateProvider', '$urlRouterProvider', createMainAppRoute]).controller('mainController', [
   '$scope', '$state', '$mdSidenav', 'userService', 'syncGlobalManager',
-  function($scope, $state, $mdSidenav, userService, syncGlobalManager) {
+  function($scope, $state, $mdSidenav, userService) {
     userService.readUser().then(function(profileData) {
       if (profileData) {
         $scope.profileData = profileData;

--- a/demo/mobile/src/app/initialisation/config.js
+++ b/demo/mobile/src/app/initialisation/config.js
@@ -18,7 +18,6 @@ angular.module('wfm-mobile').config(['$stateProvider', '$urlRouterProvider', cre
     userService.readUser().then(function(profileData) {
       if (profileData) {
         $scope.profileData = profileData;
-        syncGlobalManager.syncManagerMap(profileData);
       }
     }).catch(function() {
       console.info('Failed to retrieve profile data');

--- a/demo/mobile/src/app/sync/syncGlobalManager.js
+++ b/demo/mobile/src/app/sync/syncGlobalManager.js
@@ -124,7 +124,7 @@ function createGlobalManagerService($http, authService) {
     syncManager.syncManagerMap(profileData);
   });
 
-  authService.setLogoutListener(function(profileData) {
+  authService.setLogoutListener(function() {
     syncManager.removeManagers();
   });
   return syncManager;

--- a/demo/mobile/src/app/sync/syncGlobalManager.js
+++ b/demo/mobile/src/app/sync/syncGlobalManager.js
@@ -121,9 +121,7 @@ function createGlobalManagerService($http, authService) {
   });
   var syncManager = new SyncManager();
   authService.setLoginListener(function(profileData) {
-    if (syncManager.syncManagers.length === 0) {
-      syncManager.syncManagerMap(profileData);
-    }
+    syncManager.syncManagerMap(profileData);
   });
 
   authService.setLogoutListener(function(profileData) {

--- a/packages/angularjs-auth-passport/lib/mobileAuthService.js
+++ b/packages/angularjs-auth-passport/lib/mobileAuthService.js
@@ -72,16 +72,11 @@ MobileAuthService.prototype.login = function() {
     self.logoutListener();
   }
   localStorage.clear();
-  return self.state.go(CONSTANTS.LOGIN_STATE_ROUTE);
+  self.state.go(CONSTANTS.LOGIN_STATE_ROUTE);
 };
 
 MobileAuthService.prototype.logout = function() {
-  var self = this;
-  if (self.logoutListener) {
-    self.logoutListener();
-  }
-  localStorage.clear();
-  self.state.go(CONSTANTS.LOGIN_STATE_ROUTE, undefined, { reload: true });
+  this.login();
 };
 
 module.exports = MobileAuthService;


### PR DESCRIPTION
## Motivation
We need to clear the sync cache when a user logout so that the next user to login will not see the previous user's data. 

## Description
Remove sync manager and clear sync cache on logout. 
## Progress
- [x] Set listeners to listen when user logs out.

## Additional Notes
Related JIRA - https://issues.jboss.org/browse/RAINCATCH-1305
