### PR TITLE
 RAINCATCH-1191 - move readme content to docs

### DIFF
--- a/demo/mobile/README.md
+++ b/demo/mobile/README.md
@@ -1,6 +1,6 @@
 # FeedHenry RainCatcher Mobile
 
-This is a reference implementation of the Mobile Client application of a WFM project.
+RainCatcher mobile field operator application
 
 ## Documentation
 

--- a/demo/mobile/README.md
+++ b/demo/mobile/README.md
@@ -1,65 +1,20 @@
 # FeedHenry RainCatcher Mobile
 
-This is a reference/demo implementation of the Mobile Client application of a WFM project.
+This is a reference implementation of the Mobile Client application of a WFM project.
 
-## Local Setup
+## Documentation
 
-`npm install`
+Please refer to official RainCatcher documentation:
+http://raincatcher.feedhenry.io/docs
 
-## Running on a browser
+## Source code
 
-Being a cordova-based application, it is possible to test this application on a local browser:
+### Active development version
 
-`npm start`
+This version is used by RainCatcher developers and contains only TypeScript source code.
+https://github.com/feedhenry-raincatcher/raincatcher-angularjs/tree/master/demo/mobile
 
-or
+### Active release version
 
-`grunt serve:local --url=http://localhost:8001`
-
-The `url` parameter should be the root of the API server application running the [`fh-sync`](https://github.com/feedhenry/fh-sync) endpoints required by the running mobile demo application. See the (demo-server)[https://github.com/feedhenry-raincatcher/raincatcher-core/blob/master/demo/server/] for an implementation of the server that is expected to be available.
-
-## Running on a device emulator
-
-To run this application on a device emulator, setup the appropriate native SDKs and run the app through the following commands:
-
-1) Change config.xml content field to point to local folder
-
-`<content src="index.html?url=http://localhost:8001" />`
-
-2) Build
-
-`cordova prepare`
-`cordova build android --verbose`
-
-3) Push apk to your device
-
-`cordova run android`
-
-See the [Apache Cordova project documentation](https://cordova.apache.org/docs/) for details on how to configure your environment for running applications on a device emulator.
-
-## Repository structure
-
-### `src/app`
-Main folder containing the logic for the application. The app is mainly concerned in providing the setup and configuration values for the RainCatcher and angularjs modules that are used by it.
-
-#### `src/app/initialization`
-Contains configuration values and initial bootstrapping code for the angularjs application.
-
-#### `src/app/services`
-Contains angularjs services that are utilized by the RainCatcher modules to retrieve data. The app has the opportunity to provide an implementation that utilizes any technoligy for data retrieval, including static fixtures for testing.
-
-This demo application utilizes an [`fh-sync`](https://github.com/feedhenry/fh-sync)-based service, which would allow a mobile client to work offline for extended amounts of time, syncronizing with the server whenever a data connection becomes available again.
-
-### `src/res`
-Contains resource files (mostly bitmaps) that are used by the UI. These are also included in the various resolutions expected by the native apps.
-
-### `src/sass`
-Contains app-wide [Sass](http://sass-lang.com/) files that are compiled by the build pipeline.
-
-### `scripts/`
-Contains auxiliary scripts for the development environment.
-
-### `www/`
-Generated directory containing the output files of the local build process.
-
-This directory's contents are what is served by the local development web server.
+This version contains all resources including javascript and other build artifacts
+https://github.com/feedhenry-raincatcher/raincatcher-mobile

--- a/demo/portal/README.md
+++ b/demo/portal/README.md
@@ -1,45 +1,24 @@
 # FeedHenry RainCatcher Portal
 
-This is a reference/demo implementation of the Portal Client application of a RainCatcher project.
+Reference implementation of the Portal  application of a RainCatcher project.
 
-This repository should be used in conjunction with these following repos:
+## Documentation
 
-## Local Setup
+Please refer to official RainCatcher documentation:
+http://raincatcher.feedhenry.io/docs
 
-`npm install`
+## Source code
 
-## Running on a browser
-After installing all dependencies, run these commands to test this application on a local browser:
+### Active development version
 
-`npm start`
+This version is used by RainCatcher developers and contains only TypeScript source code.
+https://github.com/feedhenry-raincatcher/raincatcher-angularjs/tree/master/demo/portal
 
-or
+### Active release version
 
-`grunt serve:local --url=http://localhost:8001`
+This version contains all resources including javascript and other build artifacts
+https://github.com/feedhenry-raincatcher/raincatcher-portal
 
-The `url` parameter should be the root of the API server application running the [`fh-sync`](https://github.com/feedhenry/fh-sync) endpoints required by the running mobile demo application. See the (demo-server)[https://github.com/feedhenry-raincatcher/raincatcher-core/blob/master/demo/server/] for an implementation of the server that is expected to be available.
 
-## Repository structure
 
-### `src/app`
-Main folder containing the logic for the application. The app is mainly concerned in providing the setup and configuration values for the RainCatcher and angularjs modules that are used by it as well as for the [FeedHenry JavaScript SDK](https://github.com/feedhenry/fh-js-sdk).
 
-#### `src/app/services`
-Contains angularjs services that are utilized by the RainCatcher modules to retrieve data. The app has the opportunity to provide an implementation that utilizes any technoligy for data retrieval, including static fixtures for testing.
-
-This demo application utilizes an [`fh-sync`](https://github.com/feedhenry/fh-sync)-based service, which would allow the client to work offline for extended amounts of time, syncronizing with the server whenever a data connection becomes available again.
-
-#### `src/app/home`
-Has a small angularjs controller for displaying a temporary template before data is loaded from the backend server.
-
-#### `src/app/sass`
-Contains app-wide [Sass](http://sass-lang.com/) files that are compiled by the build pipeline.
-
-### `www/`
-Generated directory containing the output files of the local build process.
-
-This directory's contents are what is served by the local development web server.
-
-## Running The Demo Solution Locally
-
-The [Running The Demo Raincatcher Solution Locally](https://github.com/feedhenry-raincatcher/raincatcher-documentation/blob/master/running-locally.adoc) guide explains how to get the Raincatcher demo solution running on your local development machine. This is targeted at developers that wish to extend the existing functionality of Raincatcher modules and demo apps.

--- a/demo/portal/README.md
+++ b/demo/portal/README.md
@@ -1,6 +1,6 @@
 # FeedHenry RainCatcher Portal
 
-Reference implementation of the Portal  application of a RainCatcher project.
+RainCatcher administrator portal application
 
 ## Documentation
 


### PR DESCRIPTION
## Motivation

Move content of the README to documentation. 
Provide generic information for repository.

## Justification

We want to avoid people to try RainCatcher without checking and reading official documentation. 
apps README should point to documentation only to avoid duplication of the content. 
READMe will be included in multiple places development, productized templates etc. so we need to make sure it will be generic enough.