### PR TITLE
Show dialog when camera is not available

### DIFF
--- a/steps/examples/step-gallery/lib/angular/step.js
+++ b/steps/examples/step-gallery/lib/angular/step.js
@@ -48,7 +48,7 @@ function initModule($fh, cameraOptionsBuilder, mode) {
     };
   });
 
-  ngModule.directive('galleryForm', ['$templateCache', '$http', function($templateCache, $http) {
+  ngModule.directive('galleryForm', ['$templateCache', '$http', '$mdDialog', function($templateCache, $http, $mdDialog) {
     return {
       restrict: 'E'
       , template: $templateCache.get('wfm-template/gallery-form.tpl.html')
@@ -95,11 +95,19 @@ function initModule($fh, cameraOptionsBuilder, mode) {
         self.addImage = function(uri, id) {
           $scope.$apply(function() {
             self.model.gallery = self.model.gallery || [];
-            self.model.gallery.push({uri: uri, id: id});
+            self.model.gallery.push({ uri: uri, id: id });
           });
         };
 
         self.takePicture = function() {
+          if (!window.navigator.camera) {
+            var alert = $mdDialog.alert({
+              title: 'Camera not available in browser',
+              textContent: 'Camera plugin not available. Try running project in emulator or using `cordova run browser`.',
+              ok: 'Close'
+            });
+            return $mdDialog.show(alert);
+          }
           self.camera.capture().then(function(captureResponse) {
             captureResponse.id = uuid.create().toString();
             self.addImage(captureResponse.value, captureResponse.id);


### PR DESCRIPTION
## Motivation

To enable camera in standard browser without cordova we will need to replicate functionalities from the old camera module: 
https://github.com/raincatcher-beta/raincatcher-camera/blob/master/lib/angular/directive.js#L48-L70

## Solution

Show dialog when camera is not available:
![screen shot 2017-11-20 at 4 52 33 pm](https://user-images.githubusercontent.com/981838/33030825-3c8d80e4-ce14-11e7-8fc6-61ceed883464.png)

Follow up ticket created to resolve problem.
https://issues.jboss.org/browse/RAINCATCH-1394

